### PR TITLE
Added github repo to dist metadata and pod

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Lingua::EN::Nickname.
 
+1.35
+  * Added github repo to dist metadata and pod
+
 1.34 Sat 21 Feb 2015 11:43:16 PM PST 
   * corrected test count
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,9 +1,30 @@
 use ExtUtils::MakeMaker;
 
+my $mm_ver = $ExtUtils::MakeMaker::VERSION;
+if ($mm_ver =~ /_/) { # developer release
+    $mm_ver = eval $mm_ver;
+    die $@ if $@;
+}
+
 WriteMakefile(
   NAME            => 'Lingua::EN::Nickname',
   AUTHOR          => 'Brian Lalonde (brian@webcoder.info)',
   LICENSE         => 'perl',
   VERSION_FROM    => 'Nickname.pm', 
   ABSTRACT_FROM   => 'Nickname.pm',
+
+  ($mm_ver <= 6.45
+    ? ()
+    : (META_MERGE => {
+      'meta-spec' => { version => 2 },
+        resources => {
+          repository  => {
+            type => 'git',
+            web  => 'https://github.com/brianary/Lingua-EN-Nickname',
+            url  => 'https://github.com/brianary/Lingua-EN-Nickname.git',
+          },
+        },
+      })
+  ),
+
 );

--- a/Nickname.pm
+++ b/Nickname.pm
@@ -54,6 +54,10 @@ be less certain about them, but match more.
 
 =back
 
+=head1 REPOSITORY
+
+L<https://github.com/brianary/Lingua-EN-Nickname>
+
 =head1 AUTHOR
 
 Brian Lalonde, E<lt>brian@webcoder.infoE<gt>


### PR DESCRIPTION
Hi Brian,

This adds the github repo to the dist metadata. One of the reasons for doing this is that MetaCPAN will display a link to it in the left sidebar.

Plus, having a github repo in the metadata makes it a candidate for the [CPAN pull request challenge](http://blogs.perl.org/users/neilb/2015/01/more-details-on-the-cpan-pull-request-challenge.html).

Cheers,
Neil
